### PR TITLE
Missing permissions in policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ The AmazonDetectiveFullAccess managed policy shown below contains the permission
             "Action": [
                 "detective:CreateMembers",
                 "detective:DeleteMembers",
-                "detective:AcceptInvitation"
+                "detective:AcceptInvitation",
+                "detective:ListGraphs",
+                "detective:ListMembers"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
The role policy mentioned is missing the permissions for `"detective:ListGraphs"` and `"detective:ListMembers"`, otherwise when the script to enable Detective is executed you receive the following errors:

`2020-01-23 16:32:55,964 - ERROR - error with region us-west-2: An error occurred (AccessDeniedException) when calling the ListGraphs operation: User: arn:aws:sts::ACCOUNT:assumed-role/ROLE_NAME/EnableDetective is not authorized to perform: detective:ListGraphs on resource: *`

and

`botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the ListMembers operation: User: arn:aws:sts::ACCOUNT:assumed-role/ROLE_NAME/EnableDetective is not authorized to perform: detective:ListMembers on resource: arn:aws:detective:eu-west-1:ACCOUNT:graph:REDACTED`

Also the documentation seems a bit confusing, since in my account there is no `AmazonDetectiveFullAccess` managed policy. Is this police being rolled out to all AWS accounts or is it actually the police listed in the example? If it is the example policy, then the term `managed` can lead to confusion.