### PR TITLE
Enable Amazon Detective in regions where no graph exists

### DIFF
--- a/disableDetective.py
+++ b/disableDetective.py
@@ -277,9 +277,9 @@ if __name__ == '__main__':
             d_client = master_session.client('detective', region_name=region)
             graphs = get_graphs(d_client)
             if not graphs:
-                logging.info(f'AWS Detective is NOT disabled in {region}')
+                logging.info(f'Amazon Detective is NOT disabled in {region}')
                 continue
-            logging.info(f'AWS Detective is disabled in region {region}')
+            logging.info(f'Amazon Detective is disabled in region {region}')
 
             try:
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -180,7 +180,17 @@ def test_create_members():
     created_members = enableDetective.create_members(d_client, "graph1", {"333333333333"}, {"111111111111": "1@gmail.com", "222222222222": "2@gmail.com"})
     assert created_members == {"222222222222"}
 
+def test_enable_detective():
+    d_client = Mock()
 
+    d_client.list_graphs.return_value = {'GraphList': []}
+    d_client.create_graph.return_value = {'GraphArn': 'fooGraph123'}
+
+    graphs = enableDetective.enable_detective(d_client, "us-east-2")
+
+    assert graphs == ['fooGraph123']
+
+    
 
 
 


### PR DESCRIPTION
*Issue #, if available:* #3 

*Description of changes:* This PR updates `enableDetective.py` to optionally enable Detective in regions where no Detective graph exists for the provided master account. It also includes some minor cleanups to strings, primarily fixing our service name. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
