### PR TITLE
Support the option to add tags to newly created Detective graphs

### DIFF
--- a/enableDetective.py
+++ b/enableDetective.py
@@ -303,7 +303,7 @@ def enable_detective(d_client: botocore.client.BaseClient, region: str, tags: di
         confirm = input('Should Amazon Detective be enabled in {}? Enter [Y/N]: '.format(region))
 
         if confirm == 'Y' or confirm == 'y':
-            logging.info(f'Enabling Amazon Detective in {region}' + (f'with tags {tags}' if tags else ''))
+            logging.info(f'Enabling Amazon Detective in {region}' + (f' with tags {tags}' if tags else ''))
             graphs = [d_client.create_graph(Tags=tags)['GraphArn']]
         else:
             logging.info(f'Skipping {region}')

--- a/enableDetective.py
+++ b/enableDetective.py
@@ -46,7 +46,7 @@ def setup_command_line(args = None) -> argparse.Namespace:
         def __call__(self, parser, namespace, values, option_string=None):
             setattr(namespace, self.dest, dict())
             for kv_pairs in values.split(","):
-                key, value = kv_pairs.split('=', 1)
+                key, _, value = kv_pairs.partition('=')
                 getattr(namespace, self.dest)[key] = value
 
    # Setup command line arguments
@@ -66,7 +66,9 @@ def setup_command_line(args = None) -> argparse.Namespace:
                               'all available regions enabled.'))
     parser.add_argument('--tags',
                         action=ParseCommaSeparatedKeyValuePairsAction,
-                        help="Tags to be added to any newly enabled Detective graphs.")
+                        help='Comma-separated list of tag key-value pairs to be added '
+                             'to any newly enabled Detective graphs. Values are optional '
+                             'and are separated from keys by the equal sign (i.e. \'=\')')
     return parser.parse_args(args)
 
 

--- a/enableDetective.py
+++ b/enableDetective.py
@@ -42,7 +42,14 @@ def setup_command_line(args = None) -> argparse.Namespace:
             raise argparse.ArgumentTypeError
         return val
 
-    # Setup command line arguments
+    class ParseCommaSeparatedKeyValuePairsAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, dict())
+            for kv_pairs in values.split(","):
+                key, value = kv_pairs.split('=', 1)
+                getattr(namespace, self.dest)[key] = value
+
+   # Setup command line arguments
     parser = argparse.ArgumentParser(description=('Link AWS Accounts to central '
                                                   'Detective Account.'))
     parser.add_argument('--master_account', type=_master_account_type,
@@ -57,6 +64,9 @@ def setup_command_line(args = None) -> argparse.Namespace:
     parser.add_argument('--enabled_regions', type=str,
                         help=('Regions to enable Detective. If not specified, '
                               'all available regions enabled.'))
+    parser.add_argument('--tags',
+                        action=ParseCommaSeparatedKeyValuePairsAction,
+                        help="Tags to be added to any newly enabled Detective graphs.")
     return parser.parse_args(args)
 
 
@@ -286,15 +296,15 @@ def accept_invitations(role: str, accounts: typing.Set[str], graph: str, region:
     except Exception as e:
         logging.exception(f'error accepting invitation {e.args}')
 
-def enable_detective(d_client: botocore.client.BaseClient, region: str):
+def enable_detective(d_client: botocore.client.BaseClient, region: str, tags: dict = None):
     graphs = get_graphs(d_client)
     
     if not graphs:
         confirm = input('Should Amazon Detective be enabled in {}? Enter [Y/N]: '.format(region))
 
         if confirm == 'Y' or confirm == 'y':
-            logging.info(f'Enabling Amazon Detective in {region}')
-            graphs = [d_client.create_graph()['GraphArn']]
+            logging.info(f'Enabling Amazon Detective in {region}' + (f'with tags {tags}' if tags else ''))
+            graphs = [d_client.create_graph(Tags=tags)['GraphArn']]
         else:
             logging.info(f'Skipping {region}')
             return None
@@ -326,7 +336,7 @@ if __name__ == '__main__':
     for region in detective_regions:
         try:
             d_client = master_session.client('detective', region_name=region)
-            graphs = enable_detective(d_client, region)
+            graphs = enable_detective(d_client, region, args.tags)
 
             if graphs is None:
                 continue

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -24,6 +24,14 @@ def test_setup_command_line_enableDetective():
 
     args = enableDetective.setup_command_line(['--master_account', '000000000001', '--assume_role', 'detectiveAdmin', '--enabled_regions', 'us-east-1,us-east-2,us-west-2,ap-northeast-1,eu-west-1', '--input_file', 'accounts.csv'])
     assert args.master_account == '000000000001'
+    assert args.tags == None
+
+    args = enableDetective.setup_command_line("--master_account 123456789012 --assume_role detectiveAdmin --input_file accounts.csv --tags TagKey1=TagValue1,TagKey2=TagValue2,TagKey3=TagValue3".split(" "))
+    assert args.tags == {
+        "TagKey1": "TagValue1",
+        "TagKey2": "TagValue2",
+        "TagKey3": "TagValue3",
+    }
 
     # Wrong master account
     # The internal function _master_account_type() should raise argparse.ArgumentTypeError, however this exception gets supressed by argparse, and SystemExit is raised instead.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -26,11 +26,13 @@ def test_setup_command_line_enableDetective():
     assert args.master_account == '000000000001'
     assert args.tags == None
 
-    args = enableDetective.setup_command_line("--master_account 123456789012 --assume_role detectiveAdmin --input_file accounts.csv --tags TagKey1=TagValue1,TagKey2=TagValue2,TagKey3=TagValue3".split(" "))
+    args = enableDetective.setup_command_line("--master_account 123456789012 --assume_role detectiveAdmin --input_file accounts.csv --tags TagKey1=TagValue1,TagKey2=TagValue2,TagKey3=TagValue3,TagKey4=,TagKey5=TagValue5".split(" "))
     assert args.tags == {
         "TagKey1": "TagValue1",
         "TagKey2": "TagValue2",
         "TagKey3": "TagValue3",
+        "TagKey4": "",
+        "TagKey5": "TagValue5",
     }
 
     # Wrong master account

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -26,13 +26,14 @@ def test_setup_command_line_enableDetective():
     assert args.master_account == '000000000001'
     assert args.tags == None
 
-    args = enableDetective.setup_command_line("--master_account 123456789012 --assume_role detectiveAdmin --input_file accounts.csv --tags TagKey1=TagValue1,TagKey2=TagValue2,TagKey3=TagValue3,TagKey4=,TagKey5=TagValue5".split(" "))
+    args = enableDetective.setup_command_line("--master_account 123456789012 --assume_role detectiveAdmin --input_file accounts.csv --tags TagKey1=TagValue1,TagKey2=TagValue2,TagKey3=TagValue3,TagKey4=,TagKey5=TagValue5,TagKey6".split(" "))
     assert args.tags == {
         "TagKey1": "TagValue1",
         "TagKey2": "TagValue2",
         "TagKey3": "TagValue3",
         "TagKey4": "",
         "TagKey5": "TagValue5",
+        "TagKey6": "",
     }
 
     # Wrong master account


### PR DESCRIPTION
Introduces an optional parameter that enables tagging newly created graphs as part of the account setup process.

Note: This PR cannot be merged until an SDK with the Tagging operations for Detective is released.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
