### PR TITLE
fix: `disableDetective.py` script not working

### DIFF
--- a/disableDetective.py
+++ b/disableDetective.py
@@ -295,7 +295,8 @@ if __name__ == '__main__':
         logging.exception(f'error creating session {e.args}')
 
     #Chunk the list of accounts in the .csv into batches of 50 due to the API limitation of 50 accounts per invokation
-    for chunk in chunked(aws_account_dict.items(), 50):
+    for chunk_tuple in chunked(aws_account_dict.items(), 50):
+        chunk = {x: y for x, y in chunk_tuple}
 
         for region in detective_regions:
             try:

--- a/disableDetective.py
+++ b/disableDetective.py
@@ -256,7 +256,7 @@ def delete_members(d_client: botocore.client.BaseClient, graph_arn: str,
         for error in response['UnprocessedAccounts']:
             logging.exception(f'Could not delete member for account {error["AccountId"]} in '
                             f'graph {graph_arn}: {error["Reason"]}')
-    except e:
+    except Exception as e:
         logging.error(f'error when deleting member: {e}')
 
 def chunked(it, size):


### PR DESCRIPTION
*Issue #, if available:* #14.

*Description of changes:*

The same fix applied on #13 is being replicated here. There's also a small syntax change on the `except e` line, as this was generating another exception (`name 'e' is not defined`) while we were trying to figure out why the script was not working.

This has been worked on with @nekosoft.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
