### PR TITLE
Fix enableDetective.py to work without --tags option

### DIFF
--- a/enableDetective.py
+++ b/enableDetective.py
@@ -329,6 +329,8 @@ def chunked(it, size):
         
 if __name__ == '__main__':
     args = setup_command_line()
+    if args.tags is None:
+        args.tags = {}
     aws_account_dict = read_accounts_csv(args.input_file)
 
     try:


### PR DESCRIPTION
*Problem:*
Now executing enableDetective.py fails with the following error when --tags option isn't passed.

```
2022-05-18 09:13:13,213 - ERROR - error with region ap-northeast-2: Parameter validation failed:
Invalid type for parameter Tags, value: None, type: <class 'NoneType'>, valid types: <class 'dict'>
Traceback (most recent call last):
  File "enableDetective.py", line 358, in <module>
    graphs = enable_detective(d_client, region, args.tags)
  File "enableDetective.py", line 314, in enable_detective
    graphs = [d_client.create_graph(Tags=tags)['GraphArn']]
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 508, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 875, in _make_api_call
    api_params, operation_model, context=request_context
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 936, in _convert_to_request_dict
    api_params, operation_model
  File "/usr/local/lib/python3.7/site-packages/botocore/validate.py", line 381, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Tags, value: None, type: <class 'NoneType'>, valid types: <class 'dict'>
```

As you can see, this happens because the type of **args.tags** is different from <class 'dict'> botocore expects.

*Description of changes:*

Set {} to **args.tags** when args.tags = None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
