### PR TITLE
Fix disableDetective.py to work properly

### DIFF
--- a/disableDetective.py
+++ b/disableDetective.py
@@ -295,8 +295,8 @@ if __name__ == '__main__':
         logging.exception(f'error creating session {e.args}')
 
     #Chunk the list of accounts in the .csv into batches of 50 due to the API limitation of 50 accounts per invokation
-    for chunk in chunked(aws_account_dict.items(), 50):
-
+    for chunk_tuple in chunked(aws_account_dict.items(), 50):
+        chunk = {x: y for x, y in chunk_tuple}
         for region in detective_regions:
             try:
                 d_client = master_session.client('detective', region_name=region)
@@ -311,7 +311,7 @@ if __name__ == '__main__':
                         if not args.delete_graph:
                             delete_members(d_client, graph, chunk)
                         else:
-                            d_client.delete_graph(graph)
+                            d_client.delete_graph(GraphArn=graph)
                 except NameError as e:
                     logging.error(f'account is not defined: {e}')
                 except Exception as e:


### PR DESCRIPTION
*Problem*

Now disableDetective.py doesn't work properly.
To make it work, there are two things to be fixed.

1. Although internal delete_members function expects account_dict: typing.Dict[str, str], Tuple(str, str) is given.
2. Although boto3 delete_graph[1] expects kwargs, Non kwargs is given

[1]  delete_graph(**kwargs)
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/detective.html#Detective.Client.delete_graph

*Description of changes:*

1. Add type conversion logic `chunk = {x: y for x, y in chunk_tuple}`
2. kwargs is given when calling delete_graph

*Remarks*

Since this script is referenced from aws public documentation, IMHO this should be fixed ASAP.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
